### PR TITLE
Properly escape input to avoid the case where an attacker might pass an unsafe id

### DIFF
--- a/lib/ngp_van/client/activist_codes.rb
+++ b/lib/ngp_van/client/activist_codes.rb
@@ -8,7 +8,7 @@ module NgpVan
       end
 
       def activist_code(id:, params: {})
-        get(path: "activistCodes/#{id}", params: params)
+        get(path: "activistCodes/#{esc(id)}", params: params)
       end
     end
   end

--- a/lib/ngp_van/client/codes.rb
+++ b/lib/ngp_van/client/codes.rb
@@ -12,7 +12,7 @@ module NgpVan
       end
 
       def code(id:, params: {})
-        get(path: "codes/#{id}", params: params)
+        get(path: "codes/#{esc(id)}", params: params)
       end
 
       def create_code(body: {})
@@ -20,11 +20,11 @@ module NgpVan
       end
 
       def update_code(id:, body: {})
-        put(path: "codes/#{id}", body: body)
+        put(path: "codes/#{esc(id)}", body: body)
       end
 
       def delete_code(id:)
-        delete(path: "codes/#{id}")
+        delete(path: "codes/#{esc(id)}")
       end
     end
   end

--- a/lib/ngp_van/client/district_fields.rb
+++ b/lib/ngp_van/client/district_fields.rb
@@ -8,7 +8,7 @@ module NgpVan
       end
 
       def district_field(id:)
-        get(path: "districtFields/#{id}")
+        get(path: "districtFields/#{esc(id)}")
       end
     end
   end

--- a/lib/ngp_van/client/event_types.rb
+++ b/lib/ngp_van/client/event_types.rb
@@ -8,7 +8,7 @@ module NgpVan
       end
 
       def event_type(id:, params: {})
-        get(path: "events/types/#{id}", params: params)
+        get(path: "events/types/#{esc(id)}", params: params)
       end
     end
   end

--- a/lib/ngp_van/client/events.rb
+++ b/lib/ngp_van/client/events.rb
@@ -8,11 +8,11 @@ module NgpVan
       end
 
       def create_event_shift(id:, body: {})
-        post(path: "events/#{id}/shifts", body: body)
+        post(path: "events/#{esc(id)}/shifts", body: body)
       end
 
       def event(id:, params: {})
-        get(path: "events/#{id}", params: params)
+        get(path: "events/#{esc(id)}", params: params)
       end
 
       def events(params: {})
@@ -20,11 +20,11 @@ module NgpVan
       end
 
       def update_event(id:, body: {})
-        put(path: "events/#{id}", body: body)
+        put(path: "events/#{esc(id)}", body: body)
       end
 
       def delete_event(id:)
-        delete(path: "events/#{id}")
+        delete(path: "events/#{esc(id)}")
       end
     end
   end

--- a/lib/ngp_van/client/locations.rb
+++ b/lib/ngp_van/client/locations.rb
@@ -8,7 +8,7 @@ module NgpVan
       end
 
       def location(id:, params: {})
-        get(path: "locations/#{id}", params: params)
+        get(path: "locations/#{esc(id)}", params: params)
       end
 
       def find_or_create_location(body: {})
@@ -20,7 +20,7 @@ module NgpVan
       end
 
       def delete_location(id:)
-        delete(path: "locations/#{id}")
+        delete(path: "locations/#{esc(id)}")
       end
     end
   end

--- a/lib/ngp_van/client/minivan_exports.rb
+++ b/lib/ngp_van/client/minivan_exports.rb
@@ -8,7 +8,7 @@ module NgpVan
       end
 
       def minivan_export(id:, params: {})
-        get(path: "minivanExports/#{id}", params: params)
+        get(path: "minivanExports/#{esc(id)}", params: params)
       end
     end
   end

--- a/lib/ngp_van/client/notes.rb
+++ b/lib/ngp_van/client/notes.rb
@@ -12,7 +12,7 @@ module NgpVan
       end
 
       def note_category(id:, params: {})
-        get(path: "notes/categories/#{id}", params: params)
+        get(path: "notes/categories/#{esc(id)}", params: params)
       end
     end
   end

--- a/lib/ngp_van/client/people.rb
+++ b/lib/ngp_van/client/people.rb
@@ -16,19 +16,19 @@ module NgpVan
       end
 
       def person_by_type(id:, type:, params: {})
-        get(path: "people/#{type}:#{id}", params: params)
+        get(path: "people/#{esc(type)}:#{esc(id)}", params: params)
       end
 
       def create_canvass_responses_for_person(id:, body: {})
-        post(path: "people/#{id}/canvassResponses", body: body)
+        post(path: "people/#{esc(id)}/canvassResponses", body: body)
       end
 
       def create_canvass_responses_for_person_by_type(id:, type:, body: {})
-        post(path: "people/#{type}:#{id}/canvassResponses", body: body)
+        post(path: "people/#{esc(type)}:#{esc(id)}/canvassResponses", body: body)
       end
 
       def apply_code_to_person(id:, body: {})
-        post(path: "people/#{id}/codes", body: body)
+        post(path: "people/#{esc(id)}/codes", body: body)
       end
     end
   end

--- a/lib/ngp_van/client/printed_lists.rb
+++ b/lib/ngp_van/client/printed_lists.rb
@@ -8,7 +8,7 @@ module NgpVan
       end
 
       def printed_list(id:, params: {})
-        get(path: "printedLists/#{id}", params: params)
+        get(path: "printedLists/#{esc(id)}", params: params)
       end
     end
   end

--- a/lib/ngp_van/client/signups.rb
+++ b/lib/ngp_van/client/signups.rb
@@ -8,7 +8,7 @@ module NgpVan
       end
 
       def signup(id:, params: {})
-        get(path: "signups/#{id}", params: params)
+        get(path: "signups/#{esc(id)}", params: params)
       end
 
       def signups(params: {})
@@ -20,11 +20,11 @@ module NgpVan
       end
 
       def update_signup(id:, body: {})
-        put(path: "signups/#{id}", body: body)
+        put(path: "signups/#{esc(id)}", body: body)
       end
 
       def delete_signup(id:)
-        delete(path: "signups/#{id}")
+        delete(path: "signups/#{esc(id)}")
       end
     end
   end

--- a/lib/ngp_van/client/supporter_groups.rb
+++ b/lib/ngp_van/client/supporter_groups.rb
@@ -8,7 +8,7 @@ module NgpVan
       end
 
       def supporter_group(id:, params: {})
-        get(path: "supporterGroups/#{id}", params: params)
+        get(path: "supporterGroups/#{esc(id)}", params: params)
       end
 
       def supporter_groups(params: {})
@@ -16,11 +16,11 @@ module NgpVan
       end
 
       def add_person_to_supporter_group(supporter_group_id:, id:)
-        put(path: "supporterGroups/#{supporter_group_id}/people/#{id}")
+        put(path: "supporterGroups/#{esc(supporter_group_id)}/people/#{esc(id)}")
       end
 
       def remove_person_from_supporter_group(supporter_group_id:, id:)
-        delete(path: "supporterGroups/#{supporter_group_id}/people/#{id}")
+        delete(path: "supporterGroups/#{esc(supporter_group_id)}/people/#{esc(id)}")
       end
     end
   end

--- a/lib/ngp_van/client/survey_questions.rb
+++ b/lib/ngp_van/client/survey_questions.rb
@@ -8,7 +8,7 @@ module NgpVan
       end
 
       def survey_question(id:, params: {})
-        get(path: "surveyQuestions/#{id}", params: params)
+        get(path: "surveyQuestions/#{esc(id)}", params: params)
       end
     end
   end

--- a/lib/ngp_van/client/users.rb
+++ b/lib/ngp_van/client/users.rb
@@ -4,15 +4,15 @@ module NgpVan
   class Client
     module Users
       def user_district_field_values(id:, params: {})
-        get(path: "users/#{id}/districtFieldValues", params: params)
+        get(path: "users/#{esc(id)}/districtFieldValues", params: params)
       end
 
       def create_user_district_field_values(id:, body: {})
-        post(path: "users/#{id}/districtFieldValues", body: body)
+        post(path: "users/#{esc(id)}/districtFieldValues", body: body)
       end
 
       def update_user_district_field_values(id:, body: {})
-        put(path: "users/#{id}/districtFieldValues", body: body)
+        put(path: "users/#{esc(id)}/districtFieldValues", body: body)
       end
     end
   end

--- a/lib/ngp_van/request.rb
+++ b/lib/ngp_van/request.rb
@@ -26,9 +26,13 @@ module NgpVan
 
     private
 
+    def esc(untrusted)
+      CGI.escape(untrusted.to_s)
+    end
+
     def request(method:, path:, params: {}, body: {})
       response = connection.send(method) do |request|
-        request.path = URI.encode(path)
+        request.path = path
         request.params = params
         request.body = ::JSON.generate(body) unless body.empty?
       end

--- a/spec/ngp_van/client/codes_spec.rb
+++ b/spec/ngp_van/client/codes_spec.rb
@@ -109,6 +109,19 @@ module NgpVan
           code = client.code(id: 20_515, params: params)
           expect(code['codeId']).to eq(20_515)
         end
+
+        describe 'ssrf protection' do
+          let(:url) { 'https://api.securevan.com/v4/codes/foo%2Fbar' }
+
+          it 'should not trust the input code' do
+            client.code(id: 'foo/bar', params: params)
+
+            expect(
+                a_request(:get, url)
+                    .with(query: params)
+            ).to have_been_made
+          end
+        end
       end
 
       describe '#create_code' do


### PR DESCRIPTION
Specifically there might be a case where an attacker could cause software using this library to construct an `id` to be a string like 'foo/bar'. This could allow for Server Side Request Forgery against the NGPVAN API. 

`URI.escape`, which was previously used is deprecated and not appropriate for this situation. It does not escape '/'.

This fixes the issue by escaping the input before using it to construct a path. 