### PR TITLE
fix RaiseError middleware

### DIFF
--- a/lib/ngp_van/response/raise_error.rb
+++ b/lib/ngp_van/response/raise_error.rb
@@ -6,8 +6,6 @@ require 'faraday'
 module NgpVan
   module Response
     class RaiseError < Faraday::Response::Middleware
-      private
-
       def on_complete(response)
         error = NgpVan::Error.from_response(response)
         raise error if error

--- a/spec/ngp_van/request_spec.rb
+++ b/spec/ngp_van/request_spec.rb
@@ -62,6 +62,19 @@ module NgpVan
             .to have_been_made
         end
       end
+
+      context 'when the response has a non-success status code' do
+        before do
+          stub_request(:get, url)
+            .to_return(status: 404, body: {errors: [{code: 'NOT_FOUND', text: 'it was not found'}]}.to_json)
+        end
+
+        it 'raises an appropriate error' do
+          expect do
+            NgpVan.get(path: '/some/resource')
+          end.to raise_error(NgpVan::NotFound)
+        end
+      end
     end
 
     describe '#post' do


### PR DESCRIPTION
We're supposed to get exceptions when responses have 400-599 status codes, but those exceptions were not being raised. This fixes the issue that caused the middleware not to trigger, and adds a spec.