### PR TITLE
Update syntax for faraday basic_auth

### DIFF
--- a/lib/ngp_van/connection.rb
+++ b/lib/ngp_van/connection.rb
@@ -18,10 +18,7 @@ module NgpVan
       }
 
       Faraday::Connection.new(options) do |connection|
-        connection.basic_auth(
-          config.application_name,
-          config.api_key
-        )
+        connection.request :basic_auth, config.application_name, config.api_key
 
         connection.request(:json)
         connection.use NgpVan::Response::RaiseError

--- a/ngp_van.gemspec
+++ b/ngp_van.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |spec|
   spec.summary = 'Ruby wrapper for the NGP VAN API'
   spec.version = NgpVan::VERSION.dup
 
-  spec.add_dependency 'faraday', '>= 0.9.2'
+  spec.add_dependency 'faraday', '>= 1.0.0', '< 2.0'
   spec.add_dependency 'faraday_middleware', '>= 0.10.0'
 end


### PR DESCRIPTION
This should get rid of the "WARNING: `Faraday::Connection#basic_auth` is deprecated; it will be removed in version 2.0." warning we've been seeing in the logs.

Q: Can we submit this upstream?
A: For now, no, because upstream still wants to use Faraday <1.0, and this new syntax is for Faraday 1.x