### PR TITLE
Upgrade Faraday to  2.8.1

### DIFF
--- a/lib/ngp_van/connection.rb
+++ b/lib/ngp_van/connection.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'ngp_van/response/raise_error'
-require 'faraday_middleware'
 
 module NgpVan
   module Connection
@@ -17,8 +16,8 @@ module NgpVan
         }
       }
 
-      Faraday::Connection.new(options) do |connection|
-        connection.request :basic_auth, config.application_name, config.api_key
+      Faraday.new(options) do |connection|
+        connection.request :authorization, :basic, config.application_name, config.api_key
 
         connection.request(:json)
         connection.use NgpVan::Response::RaiseError

--- a/lib/ngp_van/response/raise_error.rb
+++ b/lib/ngp_van/response/raise_error.rb
@@ -5,7 +5,7 @@ require 'faraday'
 
 module NgpVan
   module Response
-    class RaiseError < Faraday::Response::Middleware
+    class RaiseError < Faraday::Middleware
       def on_complete(response)
         error = NgpVan::Error.from_response(response)
         raise error if error

--- a/ngp_van.gemspec
+++ b/ngp_van.gemspec
@@ -23,6 +23,5 @@ Gem::Specification.new do |spec|
   spec.summary = 'Ruby wrapper for the NGP VAN API'
   spec.version = NgpVan::VERSION.dup
 
-  spec.add_dependency 'faraday', '>= 1.0.0', '< 2.0'
-  spec.add_dependency 'faraday_middleware', '>= 0.10.0'
+  spec.add_dependency 'faraday', '>= 2.0.1', '< 3.0'
 end


### PR DESCRIPTION
The Faraday middleware gem was deprecated in 2.0, but the JSON middleware moved inside of  Faraday, so no major changes needed. There were small updates to basic  auth config and custom  error handling as well.

All specs are  now  passing, I'm happy  to run through any other checks etc. if  needed 