### PR TITLE
Handle non-JSON errors and other minor fixes to work with ruby 3.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gemspec
 
 gem 'rake', '>= 12.3.3'
 gem 'bundler'
+gem 'base64'
 
 group :test, :development do
   gem 'faker', '> 1.6'

--- a/lib/ngp_van.rb
+++ b/lib/ngp_van.rb
@@ -15,9 +15,9 @@ module NgpVan
     end
 
     # Delegate methods called on NgpVan to the client.
-    def method_missing(method_name, *args, &block)
+    def method_missing(method_name, *args, **kwargs, &block)
       return super unless client.respond_to?(method_name)
-      client.send(method_name, *args, &block)
+      client.send(method_name, *args, **kwargs, &block)
     end
   end
 

--- a/lib/ngp_van/error.rb
+++ b/lib/ngp_van/error.rb
@@ -45,11 +45,11 @@ module NgpVan
       @response = response
       if response.response_headers['Content-Type']&.match(/application\/json/i)
         @body = ::JSON.parse(response[:body])
+        @errors = body.delete('errors')
       else
         @body = response[:body]
       end
       @status = response[:status]
-      @errors = body.delete('errors')
 
       super(build_error)
     end

--- a/lib/ngp_van/error.rb
+++ b/lib/ngp_van/error.rb
@@ -43,7 +43,11 @@ module NgpVan
 
     def initialize(response = nil)
       @response = response
-      @body = ::JSON.parse(response[:body])
+      if response.response_headers['Content-Type']&.match(/application\/json/i)
+        @body = ::JSON.parse(response[:body])
+      else
+        @body = response[:body]
+      end
       @status = response[:status]
       @errors = body.delete('errors')
 

--- a/spec/ngp_van/request_spec.rb
+++ b/spec/ngp_van/request_spec.rb
@@ -69,13 +69,41 @@ module NgpVan
         end
 
         before do
-          stub_request(:get, url).to_return(status: 404, body: response_body)
+          stub_request(:get, url).to_return(status: 404, headers: { 'Content-Type' => 'application/json' }, body: response_body)
         end
 
         it 'raises an appropriate error' do
           expect do
             NgpVan.get(path: '/some/resource')
-          end.to raise_error(NgpVan::NotFound)
+          end.to raise_error(NgpVan::NotFound) do |error|
+            expect(error.errors&.count).to eq(1)
+            expect(error.errors[0]['code']).to eq('NOT_FOUND')
+            expect(error.errors[0]['text']).to eq('it was not found')
+          end
+        end
+      end
+
+      context 'when the response is not in JSON format' do
+        let(:response_body) do
+          <<-HTML
+            <html class="no-js" lang="en-US">
+              <head><title>502 Bad Gateway</title></head>
+              <body>
+                <span>Error code 502</span>
+              </body>
+            </html>
+          HTML
+        end
+
+        before do
+          stub_request(:get, url).to_return(status: 502, headers: { 'Content-Type' => 'text/html' }, body: response_body)
+        end
+
+        it 'raises an appropriate error' do
+          expect { NgpVan.get(path: '/some/resource') }
+            .to raise_error(NgpVan::BadGateway) do |error|
+              expect(error.body).to eq(response_body)
+            end
         end
       end
     end


### PR DESCRIPTION
This PR updates how we handle response errors from NGP/VAN to only attempt parsing the response as JSON if the `Content-Type` header is the correct one (i.e.: `'application/json'`).

Also includes another 2 minor fixes to work with ruby 3.4:
- Include the `base64` gem that was moved off ruby standard library into a separate gem
- Correctly handle keyword arguments on `NgpVan#method_missing` to pass them to the client's method